### PR TITLE
Reformat front-page as table of contents

### DIFF
--- a/share/templates/calendar.mhtml
+++ b/share/templates/calendar.mhtml
@@ -1,0 +1,66 @@
+<%flags>inherit => '/page.mhtml'</%flags>
+<%method content>
+<%args>
+%articles
+@calendar
+$today
+$year
+%month
+</%args>
+ 
+<table class="calendar">
+<tr>
+  <th>Sun</th>
+  <th>Mon</th>
+  <th>Tue</th>
+  <th>Wed</th>
+  <th>Thu</th>
+  <th>Fri</th>
+  <th>Sat</th>
+</tr>
+ 
+% for my $week (@calendar) {
+<tr>
+%   for my $day (map {; $_ ? $month{ $_ } : undef } @$week) {
+%     my %class;
+%     my $article = $day ? $articles{ $day->ymd } : undef;
+%     if ($day) {
+%       $class{today}  = $day->ymd eq $today->ymd;
+%       $class{future} = $day > $today;
+%       $class{advent} = $day >= $calendar->start_date
+%                     && $day <= $calendar->end_date;
+%     }
+%     $class{missing} = ! $class{future} && $class{advent} && ! $article;
+%     my $class = join q{ }, grep { $class{$_} } keys %class;
+%     if ($day) {
+    <td id="dec-<% sprintf('%02u', $day->day) %>" class="day <% $class %>">
+%       if ($article) {
+      <a class="article" title="<% $article->title |h %> (<% $article->topic |h %>)" href="<% $article->date->ymd %>.html"><% $article->date->day %></a>
+%       } else {
+      <% $day->day %>
+%       }
+%     } else {
+    <td>&nbsp;
+%     }
+    </td>
+%   }
+</tr>
+% }
+</table>
+
+<ul>
+% for my $week (@calendar) {
+%   for my $day (map {; $_ ? $month{ $_ } : undef } @$week) {
+%     my $article = $day ? $articles{ $day->ymd } : undef;
+%     if ($day && $article) {
+    <li> 
+      <a class="article" title="<% $article->title |h %> (<% $article->topic |h %>)" href="<% $article->date->ymd %>.html">
+        <% $article->date->day %> <% $article->title |h %>
+      </a>
+    </li>
+%     }
+%   }
+% }
+</ul>
+
+</%method>

--- a/share/templates/style.css
+++ b/share/templates/style.css
@@ -111,6 +111,7 @@ a:not(.article) {
 }
 
 .calendar {
+  float: right;
   margin-left: auto;
   margin-right: auto;
   margin-bottom: 1em;
@@ -124,8 +125,6 @@ a:not(.article) {
 
 .calendar td {
   text-align: center;
-  width: 9em;
-  height: 5em;
   padding: 0;
 }
 
@@ -298,6 +297,14 @@ pre, code, .code-listing {
 
 /* BEGIN CHRISTMAS:  Move to "extra CSS" */
 
+.calendar {
+    width: 30%;
+}
+.calendar td.day {
+    font-size: 0.5em;
+    padding-top: 0;
+    padding-bottom: 0;
+}
 .calendar td.day.advent.missing,
 .calendar td.day.missing#dec-25,
 .calendar td.day.missing#dec-26 {


### PR DESCRIPTION
Now that Christmas 2012 is over, it makes more sense to show the
titles as a table of contents, and de-emphasize the calendar view.
